### PR TITLE
update sendTransaction and add getFeeAssets method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,5 +66,5 @@ export interface MarinaProvider {
     getBalances(): Promise<Balance[]>;
     on(type: MarinaEventType, callback: (payload: any) => void): EventListenerID;
     off(listenerId: EventListenerID): void;
-    getTaxiAssets(): string[];
+    getTaxiAssets(): Promise<string[]>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,11 @@ export interface Balance {
     };
     amount: number;
 }
+export interface Recipient {
+    address: string;
+    value: number;
+    asset: string;
+}
 export declare type MarinaEventType = 'NEW_UTXO' | 'NEW_TX' | 'SPENT_UTXO' | 'ENABLED' | 'DISABLED' | 'NETWORK';
 export declare type TransactionHex = string;
 export declare type PsetBase64 = string;
@@ -52,7 +57,7 @@ export interface MarinaProvider {
     getAddresses(): Promise<AddressInterface[]>;
     getNextAddress(): Promise<AddressInterface>;
     getNextChangeAddress(): Promise<AddressInterface>;
-    sendTransaction(recipientAddress: string, amountInSatoshis: number, assetHash: string): Promise<TransactionHex>;
+    sendTransaction(recipients: Recipient[], feeAsset?: string): Promise<TransactionHex>;
     blindTransaction(pset: PsetBase64): Promise<PsetBase64>;
     signTransaction(pset: PsetBase64): Promise<PsetBase64>;
     signMessage(message: string): Promise<SignedMessage>;
@@ -61,4 +66,5 @@ export interface MarinaProvider {
     getBalances(): Promise<Balance[]>;
     on(type: MarinaEventType, callback: (payload: any) => void): EventListenerID;
     off(listenerId: EventListenerID): void;
+    getTaxiAssets(): string[];
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,5 +66,5 @@ export interface MarinaProvider {
     getBalances(): Promise<Balance[]>;
     on(type: MarinaEventType, callback: (payload: any) => void): EventListenerID;
     off(listenerId: EventListenerID): void;
-    getTaxiAssets(): Promise<string[]>;
+    getFeeAssets(): Promise<string[]>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,5 +66,5 @@ export interface MarinaProvider {
     getBalances(): Promise<Balance[]>;
     on(type: MarinaEventType, callback: (payload: any) => void): EventListenerID;
     off(listenerId: EventListenerID): void;
-    getFeeAssets(): Promise<string[]>;
+    getTaxiAssets(): Promise<string[]>;
 }

--- a/index.ts
+++ b/index.ts
@@ -40,6 +40,12 @@ export interface Balance {
   amount: number;
 }
 
+export interface Recipient {
+  address: string; // the recipient address
+  value: number; // the amount of sats to send
+  asset: string; // the asset to send
+}
+
 export type MarinaEventType = 'NEW_UTXO' | 'NEW_TX' | 'SPENT_UTXO' | 'ENABLED' | 'DISABLED' | 'NETWORK';
 
 export type TransactionHex = string;
@@ -66,9 +72,8 @@ export interface MarinaProvider {
   getNextChangeAddress(): Promise<AddressInterface>;
 
   sendTransaction(
-    recipientAddress: string,
-    amountInSatoshis: number,
-    assetHash: string
+    recipients: Recipient[],
+    feeAsset?: string,
   ): Promise<TransactionHex>;
 
   blindTransaction(pset: PsetBase64): Promise<PsetBase64>;
@@ -86,4 +91,6 @@ export interface MarinaProvider {
   on(type: MarinaEventType, callback: (payload: any) => void): EventListenerID;
 
   off(listenerId: EventListenerID): void;
+
+  getTaxiAssets(): string[];
 }

--- a/index.ts
+++ b/index.ts
@@ -92,5 +92,5 @@ export interface MarinaProvider {
 
   off(listenerId: EventListenerID): void;
 
-  getTaxiAssets(): Promise<string[]>;
+  getFeeAssets(): Promise<string[]>;
 }

--- a/index.ts
+++ b/index.ts
@@ -92,5 +92,5 @@ export interface MarinaProvider {
 
   off(listenerId: EventListenerID): void;
 
-  getTaxiAssets(): string[];
+  getTaxiAssets(): Promise<string[]>;
 }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   ],
   "scripts": {
     "prepare": "tsc --declaration"
+  },
+  "devDependencies": {
+    "typescript": "^4.4.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,3 +2,7 @@
 # yarn lockfile v1
 
 
+typescript@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
+  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==


### PR DESCRIPTION
related to https://github.com/vulpemventures/marina/issues/214

* `sendTransaction` now takes *a list of recipients* instead of only one and the feeAssetHash (optional, the default value is L-BTC).
* `getTaxiAssets` aims to return the list of fee assets provided by the taxi daemon.

@tiero please review