### PR TITLE
Support testnet network type

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -3,6 +3,7 @@ import {
   Balance,
   EventListenerID,
   MarinaEventType,
+  NetworkString,
   PsetBase64,
   Recipient,
   SignedMessage,
@@ -24,7 +25,7 @@ export interface MarinaProvider {
 
   setAccount(account: number): Promise<void>;
 
-  getNetwork(): Promise<'liquid' | 'regtest'>;
+  getNetwork(): Promise<NetworkString>;
 
   getAddresses(): Promise<AddressInterface[]>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,3 +71,5 @@ export type SignatureBase64 = string;
 export type NativeSegwitAddress = string;
 export type ECPublicKey = string;
 export type EventListenerID = string;
+
+export type NetworkString = 'mainnet' | 'testnet' | 'regtest';

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,4 +72,4 @@ export type NativeSegwitAddress = string;
 export type ECPublicKey = string;
 export type EventListenerID = string;
 
-export type NetworkString = 'mainnet' | 'testnet' | 'regtest';
+export type NetworkString = 'liquid' | 'testnet' | 'regtest';


### PR DESCRIPTION
add `NetworkString` in types.
use it in Marina provider.

related to Marina PR [#239](https://github.com/vulpemventures/marina/pull/239)

@tiero please review