### PR TITLE
Change sendTransaction return type

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -8,7 +8,7 @@ import {
   Recipient,
   SignedMessage,
   Transaction,
-  TransactionHex,
+  TransactionID,
   Utxo,
 } from './types';
 
@@ -36,7 +36,7 @@ export interface MarinaProvider {
   sendTransaction(
     recipients: Recipient[],
     feeAsset?: string
-  ): Promise<TransactionHex>;
+  ): Promise<TransactionID>;
 
   blindTransaction(pset: PsetBase64): Promise<PsetBase64>;
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -8,7 +8,7 @@ import {
   Recipient,
   SignedMessage,
   Transaction,
-  TransactionHash,
+  TransactionID,
   Utxo,
 } from './types';
 
@@ -36,7 +36,7 @@ export interface MarinaProvider {
   sendTransaction(
     recipients: Recipient[],
     feeAsset?: string
-  ): Promise<TransactionHash>;
+  ): Promise<TransactionID>;
 
   blindTransaction(pset: PsetBase64): Promise<PsetBase64>;
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -8,7 +8,7 @@ import {
   Recipient,
   SignedMessage,
   Transaction,
-  TransactionID,
+  TransactionHash,
   Utxo,
 } from './types';
 
@@ -36,7 +36,7 @@ export interface MarinaProvider {
   sendTransaction(
     recipients: Recipient[],
     feeAsset?: string
-  ): Promise<TransactionID>;
+  ): Promise<TransactionHash>;
 
   blindTransaction(pset: PsetBase64): Promise<PsetBase64>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,7 @@ export type MarinaEventType =
   | 'DISABLED'
   | 'NETWORK';
 
-export type TransactionHex = string;
+export type TransactionID = string;
 export type PsetBase64 = string;
 export type SignatureBase64 = string;
 export type NativeSegwitAddress = string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,7 @@ export type MarinaEventType =
   | 'DISABLED'
   | 'NETWORK';
 
-export type TransactionHash = string;
+export type TransactionID = string;
 export type PsetBase64 = string;
 export type SignatureBase64 = string;
 export type NativeSegwitAddress = string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,7 @@ export type MarinaEventType =
   | 'DISABLED'
   | 'NETWORK';
 
-export type TransactionID = string;
+export type TransactionHash = string;
 export type PsetBase64 = string;
 export type SignatureBase64 = string;
 export type NativeSegwitAddress = string;


### PR DESCRIPTION
sendTransaction used the return the hex of the signed tx, but now will broadcast the tx and then return the tx id

Previous type was TransactionHex (removed) and the new one is TransactionID

More details on why this change on https://github.com/vulpemventures/marina/issues/283

@tiero please review