### PR TITLE
Support Tapscript (Covenant identity)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "tsdx": "^0.14.1",
-    "typescript": "^4.4.3"
+    "typescript": "^4.6.3"
   },
   "prettier": {
     "printWidth": 80,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,6 +1,7 @@
 import {
   AddressInterface,
   Balance,
+  DescriptorTemplate,
   EventListenerID,
   MarinaEventType,
   NetworkString,
@@ -17,21 +18,52 @@ import {
  * Provided by marina extension at window.marina
  */
 export interface MarinaProvider {
+  // ask the extension for authorization (by hostname)
   enable(): Promise<void>;
-
+  // disable access to the extension from the current hostname
   disable(): Promise<void>;
-
+  // return true if the current hostname calling this method is authorized to access marina's provider instance
   isEnabled(): Promise<boolean>;
+  // return true if the current marina extension is ready to use connected apps
+  // i.e user done the onboarding process
+  isReady(): Promise<boolean>;
 
-  setAccount(account: number): Promise<void>;
+  // set up a listener for an event type
+  on(type: MarinaEventType, callback: (payload: any) => void): EventListenerID;
+  // remove a listener for an event type
+  off(listenerId: EventListenerID): void;
 
+  // the current network the extension is connected to
   getNetwork(): Promise<NetworkString>;
+  // return the assets accepted as network fees
+  getFeeAssets(): Promise<string[]>;
+  // which account is currently selected
+  getSelectedAccount(): Promise<string>;
 
-  getAddresses(): Promise<AddressInterface[]>;
+  createAccount(accountName: string): Promise<void>;
+
+  // select an account
+  // return true if the account is ready to be used,
+  // false if u need to set up the script templates
+  useAccount(account: string): Promise<boolean>;
+
+  /** all the methods above apply to the selected account **/
+
+  // set up descriptor templates for the current account
+  // fails if the account has already a template
+  // if not setup, changeTemplate = template
+  importTemplate(
+    template: DescriptorTemplate,
+    changeTemplate?: DescriptorTemplate
+  ): Promise<void>;
+
+  getBalances(): Promise<Balance[]>;
+  getCoins(): Promise<Utxo[]>;
+  getTransactions(): Promise<Transaction[]>;
 
   getNextAddress(): Promise<AddressInterface>;
-
   getNextChangeAddress(): Promise<AddressInterface>;
+  getAddresses(): Promise<AddressInterface[]>;
 
   sendTransaction(
     recipients: Recipient[],
@@ -39,22 +71,11 @@ export interface MarinaProvider {
   ): Promise<SentTransaction>;
 
   blindTransaction(pset: PsetBase64): Promise<PsetBase64>;
-
+  // signs input(s) owned by the current account
   signTransaction(pset: PsetBase64): Promise<PsetBase64>;
 
   signMessage(message: string): Promise<SignedMessage>;
 
-  getCoins(): Promise<Utxo[]>;
-
-  getTransactions(): Promise<Transaction[]>;
-
-  getBalances(): Promise<Balance[]>;
-
-  on(type: MarinaEventType, callback: (payload: any) => void): EventListenerID;
-
-  off(listenerId: EventListenerID): void;
-
-  getFeeAssets(): Promise<string[]>;
-
+  // force marina to start an update for the current account
   reloadCoins(): Promise<void>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,3 +81,8 @@ export interface SentTransaction {
   txid: TransactionID;
   hex: RawHex;
 }
+
+export interface DescriptorTemplate {
+  type: 'marina-descriptors';
+  template: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5946,10 +5946,10 @@ typescript@^3.7.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
-  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+typescript@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
**This PR implements the new API discussed in #18 aiming to create custom covenant marina account via descriptor templates.**

marina implementation: https://github.com/louisinger/marina/tree/marina-segwitv1

- let u create an account with `createAccount` and `importTemplate`.
- the provider's user can choose the account to use via `useAccount` (`useAccount('main')` is always defined and select the main marina account (segwit v0).
- behind the hood, marina uses a new `CovenantIdentity` to handle templates.
- https://github.com/louisinger/marina/blob/marina-segwitv1/test/descriptors.spec.ts <-- test CovenantIdentity with introspection opcodes and marina signature.

it closes #18 

@tiero please review
