### PR TITLE
add `getAccountInfo` provider method 

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -3,7 +3,7 @@ import {
   AccountInfo,
   AddressInterface,
   Balance,
-  DescriptorTemplate,
+  Template,
   EventListenerID,
   MarinaEventType,
   NetworkString,
@@ -47,7 +47,6 @@ export interface MarinaProvider {
   // get public data about an account
   getAccountInfo(accountID: AccountID): Promise<AccountInfo>;
 
-
   // create a new account, accountID must be unique
   // ask the user to unlock the wallet and generate a new sub-privatekey depending on the accountID (SLIP13)
   // use importTemplate to set up the account's descriptor(s)
@@ -86,10 +85,7 @@ export interface MarinaProvider {
   // set up descriptor templates for the current account
   // fails if the account has already a template
   // if not setup, changeTemplate = template
-  importTemplate(
-    template: DescriptorTemplate,
-    changeTemplate?: DescriptorTemplate
-  ): Promise<void>;
+  importTemplate(template: Template, changeTemplate?: Template): Promise<void>;
 
   // get next (change) address for the current selected account
   getNextAddress(): Promise<AddressInterface>;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,5 +1,6 @@
 import {
   AccountID,
+  AccountInfo,
   AddressInterface,
   Balance,
   DescriptorTemplate,
@@ -43,6 +44,9 @@ export interface MarinaProvider {
   getSelectedAccount(): Promise<AccountID>;
   // return the list of accounts
   getAccountsIDs(): Promise<AccountID[]>;
+  // get public data about an account
+  getAccountInfo(accountID: AccountID): Promise<AccountInfo>;
+
 
   // create a new account, accountID must be unique
   // ask the user to unlock the wallet and generate a new sub-privatekey depending on the accountID (SLIP13)

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,9 +101,11 @@ export interface SentTransaction {
   hex: RawHex;
 }
 
-export interface DescriptorTemplate {
-  type: 'marina-descriptors';
-  template: string;
+export type TemplateType = 'marina-descriptors' | 'ionio-artifact';
+
+export interface Template<T = any> {
+  type: TemplateType;
+  template: T;
 }
 
 export type AccountID = string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,3 +107,10 @@ export interface DescriptorTemplate {
 }
 
 export type AccountID = string;
+
+export interface AccountInfo {
+  accountID: AccountID;
+  masterXPub: string;
+  isReady: boolean; // true if the account can receive/send transactions
+  [key: string]: any; // any other key is a custom field (depends on account type)
+}


### PR DESCRIPTION
* `getAccountInfo` returns the new type `AccountInfo` (can be extended in the provider 
* re-type the `DescriptorTemplate` -> `Template<T = any>` to support `ionio-artifact` 

@tiero please review