### PR TITLE
Update provider and types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    rules: {
+        "prettier/prettier": "off",
+    }
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "prepare": "tsdx build --tsconfig tsconfig.json --entry src/index.ts"
   },
   "devDependencies": {
+    "@ionio-lang/ionio": "^0.3.0",
+    "liquidjs-lib": "^6.0.2-liquid.23",
     "tsdx": "^0.14.1",
     "typescript": "^4.6.3"
   },

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,9 +1,10 @@
 import {
   AccountID,
   AccountInfo,
-  AddressInterface,
+  AccountType,
+  Address,
+  ArtifactWithConstructorArgs,
   Balance,
-  Template,
   EventListenerID,
   MarinaEventType,
   NetworkString,
@@ -14,7 +15,6 @@ import {
   SignedMessage,
   Transaction,
   Utxo,
-  TemplateString,
 } from './types';
 
 /**
@@ -50,16 +50,13 @@ export interface MarinaProvider {
 
   // create a new account, accountID must be unique
   // ask the user to unlock the wallet and generate a new sub-privatekey depending on the accountID (SLIP13)
-  // use importTemplate to set up the account's descriptor(s)
-  createAccount(accountID: AccountID): Promise<void>;
+  createAccount(accountID: AccountID, accountType: AccountType): Promise<void>;
 
   // getters with no param = get for all accounts
   getBalances(accountIDs?: AccountID[]): Promise<Balance[]>;
   getCoins(accountIDs?: AccountID[]): Promise<Utxo[]>;
   getTransactions(accountIDs?: AccountID[]): Promise<Transaction[]>;
-  getAddresses(accountIDs?: AccountID[]): Promise<AddressInterface[]>;
-  // reloadCoins can be used to launch an update task for a given account list
-  reloadCoins(accountIDs?: AccountID[]): Promise<void>;
+  getAddresses(accountIDs?: AccountID[]): Promise<Address[]>;
 
   // coinselect coins from the account's utxo list
   // try to blind and sign if necessary, then broadcast the transaction
@@ -70,11 +67,9 @@ export interface MarinaProvider {
   // signs input(s) of the pset owned by any accounts
   signTransaction(pset: PsetBase64): Promise<PsetBase64>;
   // broadcast transaction sent by user
-  // check inputs for used coins and lock them
-  // check outputs for unconfirmed utxos and credit them
   broadcastTransaction(signedTxHex: RawHex): Promise<SentTransaction>;
 
-  // TODO implement blindTransaction
+  // blind the outputs belonging to marina accounts
   blindTransaction(pset: PsetBase64): Promise<PsetBase64>;
 
   // select an account
@@ -83,18 +78,15 @@ export interface MarinaProvider {
   useAccount(accountID: AccountID): Promise<boolean>;
   /** all the methods above apply to the selected account **/
 
-  // set up descriptor templates for the current account
-  // fails if the account has already a template
-  // if not setup, changeTemplate = template
-  importTemplate(template: Template, changeTemplate?: Template): Promise<void>;
-
   // get next (change) address for the current selected account
+  // artifact and constructorParams are optional, only used for Ionio accounts
   getNextAddress(
-    constructorParams?: Record<TemplateString, string | number>
-  ): Promise<AddressInterface>;
+    ionioArtifact?: ArtifactWithConstructorArgs
+  ): Promise<Address>;
+
   getNextChangeAddress(
-    constructorParams?: Record<TemplateString, string | number>
-  ): Promise<AddressInterface>;
+    ionioArtifact?: ArtifactWithConstructorArgs
+  ): Promise<Address>;
 
   signMessage(message: string): Promise<SignedMessage>;
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -80,9 +80,7 @@ export interface MarinaProvider {
 
   // get next (change) address for the current selected account
   // artifact and constructorParams are optional, only used for Ionio accounts
-  getNextAddress(
-    ionioArtifact?: ArtifactWithConstructorArgs
-  ): Promise<Address>;
+  getNextAddress(ionioArtifact?: ArtifactWithConstructorArgs): Promise<Address>;
 
   getNextChangeAddress(
     ionioArtifact?: ArtifactWithConstructorArgs

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,15 @@
-export interface AddressInterface {
-  confidentialAddress: string;
-  blindingPrivateKey: string;
-  derivationPath?: string;
-  publicKey?: ECPublicKey;
-  constructorParams?: Record<string, string | number>;
-  descriptor?: string;
-}
+import type { Argument, Artifact, Contract } from "@ionio-lang/ionio";
+import type { TxOutput } from "liquidjs-lib";
+
+export type TransactionID = string;
+export type PsetBase64 = string;
+export type SignatureBase64 = string;
+export type NativeSegwitAddress = string;
+export type ECPublicKey = string;
+export type EventListenerID = string;
+export type RawHex = string;
+export type AccountID = string;
+export type NetworkString = 'liquid' | 'testnet' | 'regtest';
 
 export interface SignedMessage {
   signature: SignatureBase64;
@@ -13,55 +17,51 @@ export interface SignedMessage {
   publicKey: ECPublicKey;
 }
 
-export enum TxStatusEnum {
-  Confirmed = 1,
-  Pending = 0,
-}
-
 export interface Transaction {
   txId: string;
-  status: TxStatusEnum;
-  fee: number;
-  transfers: Array<{ asset: string; amount: number }>;
+  hex?: string;
+  height: number; // 0 means unconfirmed
   explorerURL: string;
-  blocktimeMs: number;
 }
 
-// from liquidjs-lib
-interface TxOutput {
-  asset: Buffer;
-  nonce: Buffer;
-  script: Buffer;
-  value: Buffer;
-  rangeProof?: Buffer;
-  surjectionProof?: Buffer;
+export interface ScriptDetails {
+  network: NetworkString;
+  accountName: string;
+  derivationPath?: string;
+  blindingPrivateKey?: string;
 }
 
-// from liquidjs-lib
-interface UnblindOutputResult {
-  asset: Buffer;
-  assetBlindingFactor: Buffer;
-  value: string;
-  valueBlindingFactor: Buffer;
+// data structure sent to getNextAddress in order to compute a Ionio account address
+export type ArtifactWithConstructorArgs = {
+  artifact: Artifact;
+  args: { [name: string]: Argument };
+};
+
+export type IonioScriptDetails = ScriptDetails & ArtifactWithConstructorArgs;
+
+export function isIonioScriptDetails(script: ScriptDetails): script is IonioScriptDetails {
+  return (script as IonioScriptDetails).artifact !== undefined;
 }
-export interface Utxo {
+
+export type Address = {
+  confidentialAddress: string;
+  contract?: Contract;
+} & ScriptDetails;
+
+export interface UnblindingData {
+  value: number;
+  asset: string;
+  assetBlindingFactor: string;
+  valueBlindingFactor: string;
+};
+
+export interface UnblindedOutput {
   txid: string;
   vout: number;
-  prevout: TxOutput;
-  unblindData: UnblindOutputResult;
-  asset?: string;
-  value?: number;
+  blindingData?: UnblindingData; // optional, if not present it means marina can't unblind the output
 }
 
-export interface Balance {
-  asset: {
-    assetHash: string;
-    ticker?: string;
-    name?: string;
-    precision: number;
-  };
-  amount: number;
-}
+export type Utxo = UnblindedOutput & { witnessUtxo?: TxOutput, scriptDetails?: ScriptDetails };
 
 // add an OP_RETURN output
 export type DataRecipient = {
@@ -72,12 +72,24 @@ export type AddressRecipient = {
   address: string; // the recipient address
 } & AssetValue;
 
+export type Recipient = AddressRecipient | DataRecipient;
+
 interface AssetValue {
   value: number; // the amount of sats to send
   asset: string; // the asset to send
 }
 
-export type Recipient = AddressRecipient | DataRecipient;
+export interface Asset {
+  assetHash: string;
+  name: string;
+  precision: number;
+  ticker: string;
+};
+
+export interface Balance {
+  asset: Asset;
+  amount: number;
+}
 
 export type MarinaEventType =
   | 'NEW_UTXO'
@@ -87,15 +99,6 @@ export type MarinaEventType =
   | 'DISABLED'
   | 'NETWORK';
 
-export type TransactionID = string;
-export type PsetBase64 = string;
-export type SignatureBase64 = string;
-export type NativeSegwitAddress = string;
-export type ECPublicKey = string;
-export type EventListenerID = string;
-export type RawHex = string;
-
-export type NetworkString = 'liquid' | 'testnet' | 'regtest';
 
 // return object from sendTransaction
 export interface SentTransaction {
@@ -103,20 +106,15 @@ export interface SentTransaction {
   hex: RawHex;
 }
 
-export type TemplateString = string;
-
-export type TemplateType = 'ionio-artifact';
-
-export interface Template<T = any> {
-  type: TemplateType;
-  template: T;
+export enum AccountType {
+  P2WPKH = 'p2wpkh',
+  Ionio = 'ionio',
 }
-
-export type AccountID = string;
 
 export interface AccountInfo {
   accountID: AccountID;
+  type: AccountType;
   masterXPub: string;
-  isReady: boolean; // true if the account can receive/send transactions
-  [key: string]: any; // any other key is a custom field (depends on account type)
+  baseDerivationPath: string;
+  accountNetworks: NetworkString[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-
 import type { Argument, Artifact, Contract } from "@ionio-lang/ionio";
 import type { TxOutput } from "liquidjs-lib";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface Transaction {
 }
 
 export interface ScriptDetails {
-  network: NetworkString;
+  networks: NetworkString[];
   accountName: string;
   derivationPath?: string;
   blindingPrivateKey?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ export type ArtifactWithConstructorArgs = {
   args: { [name: string]: Argument };
 };
 
-export type IonioScriptDetails = ScriptDetails & ArtifactWithConstructorArgs;
+export type IonioScriptDetails = ScriptDetails & { artifact: Artifact; params: Argument[]; };
 
 export function isIonioScriptDetails(script: ScriptDetails): script is IonioScriptDetails {
   return (script as IonioScriptDetails).artifact !== undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+
 import type { Argument, Artifact, Contract } from "@ionio-lang/ionio";
 import type { TxOutput } from "liquidjs-lib";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -917,6 +917,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@ionio-lang/ionio@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@ionio-lang/ionio/-/ionio-0.3.0.tgz#dd6aa1e6fcbb90f88ce5b2938cbd47c7ca427a78"
+  integrity sha512-Uz24tOfPRDBoOtv+OjhZElbyeTo5DTHDuIOdDk415AiSK2eL1F+ILaj7G0SBTG2HwOxo8ooEL1xdo412qES0jQ==
+  dependencies:
+    liquidjs-lib "^6.0.2-liquid.23"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1263,6 +1270,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.1.tgz#0611b37db4246c937feef529ddcc018cf8e35708"
   integrity sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==
 
+"@types/node@^13.9.1":
+  version "13.13.52"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.52.tgz#03c13be70b9031baaed79481c0c0cfb0045e53f7"
+  integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
@@ -1278,6 +1290,13 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
+"@types/randombytes@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/randombytes/-/randombytes-2.0.0.tgz#0087ff5e60ae68023b9bc4398b406fea7ad18304"
+  integrity sha512-bz8PhAVlwN72vqefzxa14DKNT8jK/mV66CSjwdVQM/k3Th3EPKfUtdMniwZgMedQTFuywAsfjnZsg+pEnltaMA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/resolve@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
@@ -1289,6 +1308,13 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/wif@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/wif/-/wif-2.0.2.tgz#5bd845e29406bc7d49acca6d2a6c3230f3b53d3c"
+  integrity sha512-IiIuBeJzlh4LWJ7kVTrX0nwB60OG0vvGTaWC/SgSbVFw7uYUTF6gEuvDZ1goWkeirekJDD58Y8g7NljQh2fNkA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -1582,6 +1608,13 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.3.tgz#b55cd8e8ddf659fe89b064680e1c6a4dceab0325"
   integrity sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
 
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -1725,6 +1758,13 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-x@^3.0.2:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
+  integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -1744,6 +1784,59 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+bech32@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
+  integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
+
+bip174-liquid@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bip174-liquid/-/bip174-liquid-1.0.3.tgz#5009444091da80277c45ee90c255d7919646f907"
+  integrity sha512-e69sC0Cq2tBJuhG2+wieXv40DN13YBR/wbIjZp4Mqwpar5vQm8Ldqijdd6N33XG7LtfvQi/zKm5fSzdPY/9mgw==
+
+bip174@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/bip174/-/bip174-2.1.0.tgz#cd3402581feaa5116f0f00a0eaee87a5843a2d30"
+  integrity sha512-lkc0XyiX9E9KiVAS1ZiOqK1xfiwvf4FXDDdkDq5crcDzOq+xGytY+14qCsqz7kCiy8rpN1CRNfacRhf9G3JNSA==
+
+bip66@^1.1.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/bip66/-/bip66-1.1.5.tgz#01fa8748785ca70955d5011217d1b3139969ca22"
+  integrity sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==
+  dependencies:
+    safe-buffer "^5.0.1"
+
+bitcoin-ops@^1.4.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz#e45de620398e22fd4ca6023de43974ff42240278"
+  integrity sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==
+
+bitcoinjs-lib@^6.0.2:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/bitcoinjs-lib/-/bitcoinjs-lib-6.1.0.tgz#2e3123d63eab5e8e752fd7e2f237314f35ed738f"
+  integrity sha512-eupi1FBTJmPuAZdChnzTXLv2HBqFW2AICpzXZQLniP0V9FWWeeUQSMKES6sP8isy/xO0ijDexbgkdEyFVrsuJw==
+  dependencies:
+    bech32 "^2.0.0"
+    bip174 "^2.1.0"
+    bs58check "^2.1.2"
+    create-hash "^1.1.0"
+    ripemd160 "^2.0.2"
+    typeforce "^1.11.3"
+    varuint-bitcoin "^1.1.2"
+    wif "^2.0.1"
+
+bitset@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/bitset/-/bitset-5.1.1.tgz#b1908bd48db92b2c00ca136ec0188827e84d9b58"
+  integrity sha512-oKaRp6mzXedJ1Npo86PKhWfDelI6HxxJo+it9nAcBB0HLVvYVp+5i6yj6DT5hfFgo+TS5T57MRWtw8zhwdTs3g==
+
+blech32@^1.0.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/blech32/-/blech32-1.1.2.tgz#545459680555e229603241be3b9bf0979f6fbb3a"
+  integrity sha512-C5qxzoF9KyX88X8Zz18cZ6BOeL0n5/Eg/cDot1frntkArRMwg1djNim5wA6QFWwu0lJ1LN8iiRMN4Lp2kZzdfA==
+  dependencies:
+    long "^4.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1805,6 +1898,22 @@ bs-logger@0.x:
   integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
   dependencies:
     fast-json-stable-stringify "2.x"
+
+bs58@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
+  dependencies:
+    base-x "^3.0.2"
+
+bs58check@<3.0.0, bs58check@^2.0.0, bs58check@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
+  integrity sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==
+  dependencies:
+    bs58 "^4.0.0"
+    create-hash "^1.1.0"
+    safe-buffer "^5.1.2"
 
 bser@2.1.1:
   version "2.1.1"
@@ -1912,6 +2021,14 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+cipher-base@^1.0.1, cipher-base@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -2085,6 +2202,29 @@ cosmiconfig@^6.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.7.2"
+
+create-hash@^1.1.0, create-hash@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
+  dependencies:
+    cipher-base "^1.0.1"
+    inherits "^2.0.1"
+    md5.js "^1.3.4"
+    ripemd160 "^2.0.1"
+    sha.js "^2.4.0"
+
+create-hmac@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
+  dependencies:
+    cipher-base "^1.0.3"
+    create-hash "^1.1.0"
+    inherits "^2.0.1"
+    ripemd160 "^2.0.0"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -2264,6 +2404,15 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecpair@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ecpair/-/ecpair-2.1.0.tgz#673f826b1d80d5eb091b8e2010c6b588e8d2cb45"
+  integrity sha512-cL/mh3MtJutFOvFc27GPZE2pWL3a3k4YvzUWEOvilnfZVlH3Jwgx/7d6tlD7/75tNk8TG2m+7Kgtz0SI1tWcqw==
+  dependencies:
+    randombytes "^2.1.0"
+    typeforce "^1.18.0"
+    wif "^2.0.6"
 
 electron-to-chromium@^1.3.830:
   version "1.3.840"
@@ -2823,6 +2972,11 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
+follow-redirects@^1.14.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3080,6 +3234,15 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash-base@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
+  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
+  dependencies:
+    inherits "^2.0.4"
+    readable-stream "^3.6.0"
+    safe-buffer "^5.2.0"
+
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
@@ -3157,7 +3320,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4093,6 +4256,29 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+liquidjs-lib@^6.0.2-liquid.23:
+  version "6.0.2-liquid.23"
+  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.23.tgz#5bd8f132410e8bf1775726d78a2bde132ba405cd"
+  integrity sha512-LaHjE+n7va0CkQYCzp1OgKYTTrT4MH4wVGARBLm/oDHAWtZCGE65c9/wzkmUhqFUMd3xSnWqLHKlWD7NFMOjdg==
+  dependencies:
+    "@types/randombytes" "^2.0.0"
+    "@types/wif" "^2.0.2"
+    axios "^0.21.1"
+    bech32 "^2.0.0"
+    bip174-liquid "^1.0.3"
+    bip66 "^1.1.0"
+    bitcoin-ops "^1.4.0"
+    bitcoinjs-lib "^6.0.2"
+    bitset "^5.1.1"
+    blech32 "^1.0.1"
+    bs58check "^2.0.0"
+    create-hash "^1.2.0"
+    ecpair "^2.0.1"
+    slip77 "^0.2.0"
+    typeforce "^1.11.3"
+    varuint-bitcoin "^1.1.2"
+    wif "^2.0.1"
+
 load-json-file@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
@@ -4166,6 +4352,11 @@ lolex@^5.0.0:
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -4224,6 +4415,15 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+md5.js@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+    safe-buffer "^5.1.2"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -4887,6 +5087,15 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
+readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 realpath-native@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-2.0.0.tgz#7377ac429b6e1fd599dc38d08ed942d0d7beb866"
@@ -5125,6 +5334,14 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
+ripemd160@^2.0.0, ripemd160@^2.0.1, ripemd160@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+
 rollup-plugin-sourcemaps@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.6.3.tgz#bf93913ffe056e414419607f1d02780d7ece84ed"
@@ -5195,7 +5412,7 @@ sade@^1.4.2:
   dependencies:
     mri "^1.1.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -5283,6 +5500,14 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
+sha.js@^2.4.0, sha.js@^2.4.8:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -5353,6 +5578,15 @@ slice-ansi@^2.1.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
+
+slip77@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/slip77/-/slip77-0.2.0.tgz#7aaee4cdbbb148a8cbf9ecffe86dd7f8c0fce38c"
+  integrity sha512-LQaxb1Hef10kU36qvk71tlSt5BWph7GM0j+t2n5zs169X4QfnNbb6xqKZ38X3ETzGmCQaVdBwr925HDagHra/Q==
+  dependencies:
+    "@types/node" "^13.9.1"
+    create-hmac "^1.1.7"
+    typeforce "^1.18.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -5572,6 +5806,13 @@ string.prototype.trimstart@^1.0.4:
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 strip-ansi@^4.0.0:
   version "4.0.0"
@@ -5941,6 +6182,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typeforce@^1.11.3, typeforce@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
+  integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
+
 typescript@^3.7.3:
   version "3.9.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
@@ -6029,6 +6275,11 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
 uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -6055,6 +6306,13 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+varuint-bitcoin@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz#e76c138249d06138b480d4c5b40ef53693e24e92"
+  integrity sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==
+  dependencies:
+    safe-buffer "^5.1.1"
 
 verror@1.10.0:
   version "1.10.0"
@@ -6150,6 +6408,13 @@ which@^2.0.1, which@^2.0.2:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wif@^2.0.1, wif@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/wif/-/wif-2.0.6.tgz#08d3f52056c66679299726fade0d432ae74b4704"
+  integrity sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==
+  dependencies:
+    bs58check "<3.0.0"
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
**This PR is related to** https://github.com/vulpemventures/marina/pull/436

https://github.com/louisinger/vault-calculator is using this new provider and the new Marina extension version.

TL;DR

* remove `importTemplate` and pass the Ionio `Artifact` in getNext*Address functions.
* remove `reloadCoins`, Marina is now subscribing to new scripts and auto-update the state.
* modify some types (remove LDK related types), some of them (`ScriptDetails`, ̀Address`, ̀AccountDetails` are reused in Marina.
* `createAccount` is now expecting ̀AccountType` (P2WPKH or Ionio).
* use `import type` to get types from external libs.