### PR TITLE
add publicKey in `Address` type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export type Address = {
   unconfidentialAddress?: string;
   contract?: Contract;
   script: string;
+  publicKey: string; // the public key associated with the derivation path
 } & ScriptDetails;
 
 export interface UnblindingData {


### PR DESCRIPTION
add the member `publicKey: string` in `Address` type: bip32 generated public key associated with the address derivation path (hex encoded).

it closes #15 
